### PR TITLE
fix: Skipped quiz

### DIFF
--- a/.github/workflows/report_quiz/report_quiz.sh
+++ b/.github/workflows/report_quiz/report_quiz.sh
@@ -46,14 +46,21 @@ main(){
         # We suppose that at this point we will have at least 2 options valid
         options=$([ -z "$A" ] || echo $(escp "$A"))$([ -z "$B" ] || echo ,$(escp "$B"))$([ -z "$C" ] || echo ,$(escp "$C"))$([ -z "$D" ] || echo ,$(escp "$D"))
         echo $options
+        
+        # We verify if the options don't exceed the max length
+        max_length=100
+        if [ ${#A} -gt $max_length ] || [ ${#B} -gt $max_length ] || [ ${#C} -gt $max_length ] || [ ${#D} -gt $max_length ]; then
+            echo "[skipped] one option exceed the max max_length $max_length"
+        else
+            echo "msg: $msg"
+            echo "----------------------------------------------"
+            echo "options: $options"
+            echo "----------------------------------------------"
 
-        echo "msg: $msg"
-        echo "----------------------------------------------"
-        echo "options: $options"
-        echo "----------------------------------------------"
+            send_message $CHAT_ID "$msg"
+            send_poll $CHAT_ID "$options"
+        fi
 
-        send_message $CHAT_ID "$msg"
-        send_poll $CHAT_ID "$options"
     done
 }
 

--- a/.github/workflows/report_quiz/report_quiz.sh
+++ b/.github/workflows/report_quiz/report_quiz.sh
@@ -51,6 +51,8 @@ main(){
         max_length=100
         if [ ${#A} -gt $max_length ] || [ ${#B} -gt $max_length ] || [ ${#C} -gt $max_length ] || [ ${#D} -gt $max_length ]; then
             echo "[skipped] one option exceed the max max_length $max_length"
+            # We look for another quiz
+            main
         else
             echo "msg: $msg"
             echo "----------------------------------------------"

--- a/.github/workflows/report_quiz/report_quiz.sh
+++ b/.github/workflows/report_quiz/report_quiz.sh
@@ -49,16 +49,16 @@ propose_quiz(){
         options=$([ -z "$A" ] || echo $(escp "$A"))$([ -z "$B" ] || echo ,$(escp "$B"))$([ -z "$C" ] || echo ,$(escp "$C"))$([ -z "$D" ] || echo ,$(escp "$D"))
         echo $options
         
+        echo "msg: $msg"
+        echo "----------------------------------------------"
+        echo "options: $options"
+        echo "----------------------------------------------"
+
         # We verify if the options don't exceed the max length
         if [ ${#A} -gt $MAX_LENGTH ] || [ ${#B} -gt $MAX_LENGTH ] || [ ${#C} -gt $MAX_LENGTH ] || [ ${#D} -gt $MAX_LENGTH ]; then
             echo "[skipped] one option exceed the max max_length $MAX_LENGTH"
             exit 1
         else
-            echo "msg: $msg"
-            echo "----------------------------------------------"
-            echo "options: $options"
-            echo "----------------------------------------------"
-
             send_message $CHAT_ID "$msg"
             send_poll $CHAT_ID "$options"
 

--- a/.github/workflows/report_quiz/report_quiz.sh
+++ b/.github/workflows/report_quiz/report_quiz.sh
@@ -6,6 +6,7 @@ set -e
 CHAT_ID=$1
 TELEGRAM_BOT_TOKEN=$2
 QUIZAPI_KEY=$3
+MAX_LENGTH=100
 skipped_quizzes=0
 
 # To escapes some stupid quotes
@@ -49,9 +50,8 @@ propose_quiz(){
         echo $options
         
         # We verify if the options don't exceed the max length
-        max_length=100
-        if [ ${#A} -gt $max_length ] || [ ${#B} -gt $max_length ] || [ ${#C} -gt $max_length ] || [ ${#D} -gt $max_length ]; then
-            echo "[skipped] one option exceed the max max_length $max_length"
+        if [ ${#A} -gt $MAX_LENGTH ] || [ ${#B} -gt $MAX_LENGTH ] || [ ${#C} -gt $MAX_LENGTH ] || [ ${#D} -gt $MAX_LENGTH ]; then
+            echo "[skipped] one option exceed the max max_length $MAX_LENGTH"
             exit 1
         else
             echo "msg: $msg"


### PR DESCRIPTION
When a quiz cannot be submitted (one answer exceed the mex length), another quiz is fetched instead of end the operation. After 3 quizzes skipped, the operation is aborted.