### PR TITLE
fix: return is better than exit

### DIFF
--- a/.github/workflows/report_quiz/report_quiz.sh
+++ b/.github/workflows/report_quiz/report_quiz.sh
@@ -57,12 +57,12 @@ propose_quiz(){
         # We verify if the options don't exceed the max length
         if [ ${#A} -gt $MAX_LENGTH ] || [ ${#B} -gt $MAX_LENGTH ] || [ ${#C} -gt $MAX_LENGTH ] || [ ${#D} -gt $MAX_LENGTH ] || [ ${#E} -gt $MAX_LENGTH ] || [ ${#F} -gt $MAX_LENGTH ]; then
             echo "[skipped] one option exceed the max max_length $MAX_LENGTH"
-            exit 1
+            return 1
         else
             send_message $CHAT_ID "$(escp $msg)"
             send_poll $CHAT_ID "$options"
 
-            exit 0
+            return 0
         fi
 
     done


### PR DESCRIPTION
## What?
The status code of the function **propose_quiz** wasn't really returned.

## Why?
Inside a function, it's better to use the keyword **return** to do it.

## How?
Replace the keyword **exit** of the function **propose_quiz** by the keyword **return**.