### PR TITLE
fix: reusable notify_on_pull_request_open.yaml github action

### DIFF
--- a/.github/workflows/notify_on_pull_request_open.yaml
+++ b/.github/workflows/notify_on_pull_request_open.yaml
@@ -17,7 +17,9 @@ jobs:
     name: notify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
+        with:
+          repository: osscameroon/global-github-actions
       - name: notify telegram when pull request is a created
         shell: bash
         run: |


### PR DESCRIPTION
it appears that we needed to checkout the actual
osscameroon/globla-github-actions repository for the action to work
properly