### PR TITLE
fix(report_jokes): problem to install python3.9

### DIFF
--- a/.github/workflows/report_jokes.yaml
+++ b/.github/workflows/report_jokes.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.9
+          python-version: 3.11
 
       - name: Fetch and render joke
         run: |


### PR DESCRIPTION
### Related issues
#120 

### Change
Migration to python 3.11 instead.