### PR TITLE
chore: resurrect report job bot

### DIFF
--- a/.github/workflows/report_jobs.yaml
+++ b/.github/workflows/report_jobs.yaml
@@ -1,29 +1,29 @@
 # ---
 
-# name: telegram jobs report
-# on:
-#   schedule:
-#     - cron: "0 15 * * *"
+name: telegram jobs report
+on:
+  schedule:
+    - cron: "0 15 * * 1"
 
-# jobs:
-#   build:
-#     defaults:
-#       run:
-#         working-directory: ./.github/workflows/report_jobs
+jobs:
+  build:
+    defaults:
+      run:
+        working-directory: ./.github/workflows/report_jobs
 
-#     name: Build
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@master
-#       - name: get available jobs
-#         shell: bash
-#         run: |
-#           ./report_jobs.sh > report_jobs &&
-#           cat report_jobs
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: get available jobs
+        shell: bash
+        run: |
+          ./report_jobs.sh > report_jobs &&
+          cat report_jobs
 
-#       - name: send jobs report to osscameroon group
-#         uses: appleboy/telegram-action@v0.1.1
-#         with:
-#           to: ${{ secrets.TELEGRAM_REMOTEJOBS_GROUP_ID }}
-#           token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-#           message_file: ./.github/workflows/report_jobs/report_jobs
+      - name: send jobs report to osscameroon group
+        uses: appleboy/telegram-action@v0.1.1
+        with:
+          to: ${{ secrets.TELEGRAM_REMOTEJOBS_GROUP_ID }}
+          token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          message_file: ./.github/workflows/report_jobs/report_jobs


### PR DESCRIPTION
## WHAT

- resurrect report job bot
- (offscene) re-enabled some git workflows Actions that were disabled (on monthly run only)

for : https://github.com/osscameroon/roadmap/issues/21