### PR TITLE
chore: add dependabot to fix all the deprecated github-actions versio…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
…ns for existing workflows


for : https://github.com/osscameroon/roadmap/issues/21